### PR TITLE
New matches potential fix for pattern.video.sources

### DIFF
--- a/source/net/filebot/media/ReleaseInfo.properties
+++ b/source/net/filebot/media/ReleaseInfo.properties
@@ -1,5 +1,5 @@
 # patterns for all video sources
-pattern.video.source: CAMRip|CAM|PDVD|TS|TELESYNC|PDVD|PTVD|PPVRip|Screener|SCR|SCREENER|DVDSCR|DVDSCREENER|BDSCR|R4|R5|R5LINE|R5.LINE|DVD|DVD5|DVD9|DVDRip|DVDR|TVRip|DSR|PDTV|SDTV|HDTV|HDTVRip|DVB|DVBRip|DTHRip|VODRip|VODR|BDRip|BRRip|BluRay|Blu.Ray|BD|BDR|BD25|BD50|3D.BluRay|3DBluRay|3DBD|Remux|BDRemux|BR.Scr|BR.Screener|HDDVD|HDRip|WorkPrint|VHS|VCD|TELECINE|WEBRip|WEB.Rip|WEBDL|WEB.DL|WEBCap|WEB.Cap|ithd|iTunesHD|Laserdisc|NetflixHD|VHSRip|LaserRip|URip|UnknownRip|MicroHD
+pattern.video.source: CAMRip|CAM|PDVD|TS|TELESYNC|PDVD|PTVD|PPVRip|Screener|SCR|SCREENER|DVDSCR|DVDSCREENER|BDSCR|R4|R5(?:.?LINE)?|DVD|DVD5|DVD9|DVDRip|DVDR|TVRip|DSR|(?:P|H|S)DTV|HDTVRip|(?:DVB|DTH)(?:Rip)?|VODR(?:ip)?|B(?:D|R).?Rip|Blu.?Ray|BD(?:R|25|50)?|3D.?BluRay|3DBD|(?:BD)?(?:Remux)|BR.?(?:Scr|Screener)|HD(?:DVD|Rip)|WorkPrint|VHS|VCD|TELECINE|WEB.?(?:Rip|DL|Cap)|ithd|iTunesHD|Laserdisc|NetflixHD|VHSRip|LaserRip|URip|UnknownRip|MicroHD
 
 # patterns for all video tags
 pattern.video.tags: Extended|Uncensored|Remastered|Unrated|Uncut|IMAX|(Ultimate.)?(Director.?s|Theatrical|Ultimate|Final|Rogue|Collectors|Special|Despecialized).(Cut|Edition|Version)


### PR DESCRIPTION
Whilst looking for implmentations of correctly decting the film name and
year from the many formats I came across this and have suggested this
change as I  have adapted your pattern as such for my app. Though I might
as well let you know.

Added match for br-rip
fixed match for r5.line (did not match on 101regex
i am assuing you are using \b()\b as i could not make all matches
without that
Also consolidated some regex